### PR TITLE
Added geometry type function

### DIFF
--- a/ewkb/decoder_test.go
+++ b/ewkb/decoder_test.go
@@ -165,6 +165,8 @@ func TestGeometryCollection(t *testing.T) {
 			t.Fatalf("Failed to convert geom: error = %s", err)
 		}
 
+		assert.Equal(t, "geometrycollection", g.Type())
+
 		gcol := g.(*geom.GeometryCollection)
 
 		t.Log(gcol)
@@ -218,6 +220,8 @@ func TestMultiPolygon(t *testing.T) {
 		if err != nil {
 			t.Fatal("Failed to parse MultiPolygon: err = ", err)
 		}
+
+		assert.Equal(t, "multipolygon", g.Type())
 
 		mpolygon := g.(*geom.MultiPolygon)
 
@@ -319,6 +323,8 @@ func TestMultiLineString(t *testing.T) {
 			t.Fatal("Failed to parse MultiLineString: err = ", err)
 		}
 
+		assert.Equal(t, "multilinestring", g.Type())
+
 		mlstring := g.(*geom.MultiLineString)
 
 		t.Log(mlstring)
@@ -387,6 +393,8 @@ func TestMultiPoint(t *testing.T) {
 			t.Fatal("Failed to parse MultiPoint: err = ", err)
 		}
 
+		assert.Equal(t, "multipoint", g.Type())
+
 		mpoint := g.(*geom.MultiPoint)
 
 		t.Log(mpoint)
@@ -437,6 +445,8 @@ func TestHolePolygon(t *testing.T) {
 		if err != nil {
 			t.Fatal("Failed to parse HolePolygon: err = ", err)
 		}
+
+		assert.Equal(t, "polygon", g.Type())
 
 		polygon := g.(*geom.Polygon)
 
@@ -512,6 +522,8 @@ func TestPolygon(t *testing.T) {
 			t.Fatal("Failed to parse Polygon: err = ", err)
 		}
 
+		assert.Equal(t, "polygon", g.Type())
+
 		polygon := g.(*geom.Polygon)
 
 		t.Log(polygon)
@@ -569,6 +581,8 @@ func TestLineString(t *testing.T) {
 		if err != nil {
 			t.Fatal("Failed to parse LineString: err = ", err)
 		}
+
+		assert.Equal(t, "linestring", g.Type())
 
 		lstring := g.(*geom.LineString)
 
@@ -661,6 +675,8 @@ func TestDimensionsAndEndian(t *testing.T) {
 		if err != nil {
 			t.Fatal("Failed to parse geom: err = ", err)
 		}
+
+		assert.Equal(t, "point", g.Type())
 
 		point := g.(*geom.Point)
 

--- a/types.go
+++ b/types.go
@@ -45,6 +45,7 @@ func (d Dimension) String() string {
 type Geometry interface {
 	Dimension() Dimension
 	SRID() uint32
+	Type() string
 }
 
 // Hdr represents core information about the geometry
@@ -67,10 +68,18 @@ type Point struct {
 	Coordinate
 }
 
+func (p *Point) Type() string {
+	return "point"
+}
+
 // MultiPoint
 type MultiPoint struct {
 	Hdr
 	Points []Point
+}
+
+func (m *MultiPoint) Type() string {
+	return "multipoint"
 }
 
 // LineString
@@ -79,10 +88,18 @@ type LineString struct {
 	Coordinates []Coordinate
 }
 
+func (l *LineString) Type() string {
+	return "linestring"
+}
+
 // MultiLineString
 type MultiLineString struct {
 	Hdr
 	LineStrings []LineString
+}
+
+func (l *MultiLineString) Type() string {
+	return "multilinestring"
 }
 
 // Polygon
@@ -91,16 +108,28 @@ type Polygon struct {
 	Rings []LinearRing
 }
 
+func (l *Polygon) Type() string {
+	return "polygon"
+}
+
 // MultiPolygon
 type MultiPolygon struct {
 	Hdr
 	Polygons []Polygon
 }
 
+func (l *MultiPolygon) Type() string {
+	return "multipolygon"
+}
+
 // GeometryCollection (a misnomer IMHO - should be called MultiGeometry)
 type GeometryCollection struct {
 	Hdr
 	Geometries []Geometry
+}
+
+func (l *GeometryCollection) Type() string {
+	return "geometrycollection"
 }
 
 // LinearRing


### PR DESCRIPTION
Geometry instances can now be queried by calling 'Type()' on the geometry interface for a string representation of the type. The following strings are returned:

point
linestring
polygon
multipoint
multilinestring
multipolygon
geometrycollection
